### PR TITLE
Add wakeup-source to kscan0 so keypresses wake the board from deep sleep

### DIFF
--- a/config/boards/shields/keyball61/keyball61_left.overlay
+++ b/config/boards/shields/keyball61/keyball61_left.overlay
@@ -7,6 +7,7 @@
 #include "keyball61.dtsi"
 
 &kscan0 {
+	wakeup-source;
 	row-gpios
         = <&pro_micro 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
         , <&pro_micro 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>

--- a/config/boards/shields/keyball61/keyball61_right.overlay
+++ b/config/boards/shields/keyball61/keyball61_right.overlay
@@ -11,6 +11,7 @@
 };
 
 &kscan0 {
+    wakeup-source;
     row-gpios
         = <&pro_micro 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
         , <&pro_micro 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>


### PR DESCRIPTION
A ZMK regression from the soft-off feature merge means kscan nodes now default to wakeup-source = off. Without this property explicitly set, the board can enter deep sleep normally but no keypress will wake it back up, requiring a physical reset on both halves.

See https://github.com/mmccoyd/zmk-config/issues/11 for the upstream report and root cause.